### PR TITLE
input() command w/o parameter

### DIFF
--- a/src/tabs/programming.ts
+++ b/src/tabs/programming.ts
@@ -115,7 +115,7 @@ const initializePythonEngine = async () => {
     stderr: (text: string) => printStderr(text),
   })
 
-  pyodide.runPython('import js\ndef input(prompt):\n  return js.prompt(prompt)\n\n')
+  pyodide.runPython('import js\ndef input(prompt=\'\'):\n  return js.prompt(prompt)\n\n')
 
   pyodide.loadPackage('numpy')
 


### PR DESCRIPTION
Fix issue to comply with Python 3 documentation which allows input() without prompt parameter (https://docs.python.org/3/library/functions.html#input)
Test with valid Python 3:
a=input()
print(a)